### PR TITLE
Banish Mac OSX's .DS_Store files from being tracked by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 # Ignore all logfiles and tempfiles.
 /log/*.log
 /tmp
+
+# Banish Mac OSX's .DS_Store files
+.DS_Store


### PR DESCRIPTION
My local repo was being plagued by git tracking Mac's .DS_Store files (aargh!). This little update to the .gitignore file fixes that by telling git to ignore them.