### PR TITLE
Valid move bishop

### DIFF
--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -1,3 +1,30 @@
 class Bishop < Piece
+  def valid_move?(dest_x, dest_y)
+    # # Guard against a destination matching a piece's current location
+    # return false if [dest_x, dest_y] == [self.x_position, self.y_position]
 
+    # # Guard against a destination that is outside a chessboard's grid
+    # return false if dest_x < 1 || dest_x > 8
+    # return false if dest_y < 1 || dest_y > 8
+    
+    # Get the difference between a piece's current x_position and dest_x
+    x_delta = (self.x_position - dest_x).abs
+
+    # Get the difference between a piece's current y_position and dest_y
+    y_delta = (self.y_position - dest_y).abs
+
+    # # Ensure the params match a king's moveset of 1 square in any direction
+    # if x_delta < 2 && y_delta < 2
+    #   true
+    # else 
+    #   false
+    # end
+
+    # Ensure it can only move diagonally
+    if x_delta == y_delta
+      true
+    else
+      false
+    end
+  end
 end

--- a/app/models/bishop.rb
+++ b/app/models/bishop.rb
@@ -1,30 +1,20 @@
 class Bishop < Piece
   def valid_move?(dest_x, dest_y)
-    # # Guard against a destination matching a piece's current location
-    # return false if [dest_x, dest_y] == [self.x_position, self.y_position]
+    # Guard against a destination matching a piece's current location
+    return false if [dest_x, dest_y] == [self.x_position, self.y_position]
 
-    # # Guard against a destination that is outside a chessboard's grid
-    # return false if dest_x < 1 || dest_x > 8
-    # return false if dest_y < 1 || dest_y > 8
+    # Guard against a destination that is outside a chessboard's grid
+    return false if dest_x < 1 || dest_x > 8
+    return false if dest_y < 1 || dest_y > 8
     
-    # Get the difference between a piece's current x_position and dest_x
-    x_delta = (self.x_position - dest_x).abs
+    # Guard against obstructions
+    return false if is_obstructed?(dest_x, dest_y) == true
 
-    # Get the difference between a piece's current y_position and dest_y
-    y_delta = (self.y_position - dest_y).abs
+    # Get the difference between the starting and ending x and y coordinates
+    delta_x = (self.x_position - dest_x).abs
+    delta_y = (self.y_position - dest_y).abs
 
-    # # Ensure the params match a king's moveset of 1 square in any direction
-    # if x_delta < 2 && y_delta < 2
-    #   true
-    # else 
-    #   false
-    # end
-
-    # Ensure it can only move diagonally
-    if x_delta == y_delta
-      true
-    else
-      false
-    end
+    # Ensure the bishop's destination is only on a diagonal path
+    delta_x == delta_y ? true : false
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -6,6 +6,13 @@ class Piece < ActiveRecord::Base
 		%w(Pawn Rook Knight Bishop Queen King)
 	end
 
+  # This checks the database for a potential obstacle on a single location
+  def obstacle?(check_x, check_y)
+    game.pieces.exists?(:x_position => check_x,
+                        :y_position => check_y,
+                        :active => 1)   
+  end
+
   def is_obstructed?(dest_x, dest_y)
       # Get the piece's starting coordinates
       start_x = self.x_position
@@ -30,13 +37,6 @@ class Piece < ActiveRecord::Base
         increment_y = 1
       else
         increment_y = -1
-      end
-
-      # This function checks the database for a potential obstacle
-      def obstacle?(check_x, check_y)
-        game.pieces.exists?(:x_position => check_x,
-                            :y_position => check_y,
-                            :active => 1)   
       end
       
       #--------------------------------------------------

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -2,14 +2,7 @@ require 'test_helper'
 
 class GamesControllerTest < ActionController::TestCase
   test "show board for selected game == 1" do 
-    @game = Game.create(id: 1)
-    @selected_piece = Piece.where(type: "Queen", color: "1")
-    @pieces = @game.pieces
-    
-    redirect_to :show {controller: :games, id: id}
-
-    expected = Game.find(params[:id])
-
-    assert_template_layout(expected)
+    game_id = '1'
+    assert_routing '/games/1', {action: "show", controller: "games", id: game_id}
   end
 end

--- a/test/models/bishop_test.rb
+++ b/test/models/bishop_test.rb
@@ -1,0 +1,142 @@
+require 'test_helper'
+
+class BishopTest < ActiveSupport::TestCase
+  test "moves that are valid" do
+    bishop = Piece.create(:type => 'Bishop', :x_position => 5, :y_position => 5)
+
+    # Assume is_obstructed? == false (this means there are no obstructions)
+    expected = true
+    
+    # Test 1 sqare move northeast
+    actual = bishop.valid_move?(6, 6)
+
+    assert_equal expected, actual
+
+    # Test a valid move southeast
+    actual = bishop.valid_move?(6, 4)
+
+    assert_equal expected, actual
+
+    # Test a valid move southwest
+    actual = bishop.valid_move?(4, 4)
+
+    assert_equal expected, actual
+
+    # Test a valid move northwest
+    actual = bishop.valid_move?(4, 6)
+
+    assert_equal expected, actual
+  end
+
+  # test "moves that are invalid" do
+  #   bishop = Piece.create(:type => 'Bishop', :x_position => 5, :y_position => 5)
+
+  #   # Assume is_obstructed? == false (this means there are no obstructions)
+    
+  #   expected = false
+
+  #   # Test invalid move east
+  #   actual = bishop.valid_move?(7, 5)
+
+  #   assert_equal expected, actual
+
+  #   # Test invalid move west
+  #   actual = bishop.valid_move?(3, 5)
+
+  #   assert_equal expected, actual
+
+  #   # Test invalid move south
+  #   actual = bishop.valid_move?(5, 3)
+ 
+  #   assert_equal expected, actual
+
+  #   # Test invalid move north
+  #   actual = bishop.valid_move?(5, 7)
+
+  #   assert_equal expected, actual
+
+  #   # Test invalid move northeast
+  #   actual = bishop.valid_move?(7, 7)
+
+  #   assert_equal expected, actual
+
+  #   # Test invalid move southeast
+  #   actual = bishop.valid_move?(7, 3)
+
+  #   assert_equal expected, actual
+
+  #   # Test invalid move southwest
+  #   actual = bishop.valid_move?(3, 3)
+
+  #   assert_equal expected, actual
+
+  #   # Test invalid move northwest
+  #   actual = bishop.valid_move?(3, 7)
+
+  #   assert_equal expected, actual
+
+  #   #--------------------------------------------------
+  #   # Tests for edge cases:
+
+  #   # Test invalid non-move where the params match the piece's current location
+  #   actual = bishop.valid_move?(5, 5)
+
+  #   assert_equal expected, actual
+
+  #   # Test invalid move east ouside the chessboard
+  #   bishop.update(:x_position => 8, :y_position => 5)
+
+  #   actual = bishop.valid_move?(9, 5)
+
+  #   assert_equal expected, actual
+
+  #   # Test invalid move south ouside the chessboard
+  #   bishop.update(:x_position => 5, :y_position => 1)
+
+  #   actual = bishop.valid_move?(5, 0)
+
+  #   assert_equal expected, actual
+
+  #   # Test invalid move west ouside the chessboard
+  #   bishop.update(:x_position => 1, :y_position => 5)
+
+  #   actual = bishop.valid_move?(0, 5)
+
+  #   assert_equal expected, actual
+
+  #   # Test invalid move north ouside the chessboard
+  #   bishop.update(:x_position => 5, :y_position => 8)
+
+  #   actual = bishop.valid_move?(5, 9)
+
+  #   assert_equal expected, actual
+
+  #   # Test invalid move northeast ouside the chessboard
+  #   bishop.update(:x_position => 8, :y_position => 8)
+
+  #   actual = bishop.valid_move?(9, 9)
+
+  #   assert_equal expected, actual
+
+  #   # Test invalid move southeast ouside the chessboard
+  #   bishop.update(:x_position => 8, :y_position => 1)
+
+  #   actual = bishop.valid_move?(9, 0)
+
+  #   assert_equal expected, actual
+
+  #   # Test invalid move southwest ouside the chessboard
+  #   bishop.update(:x_position => 1, :y_position => 1)
+
+  #   actual = bishop.valid_move?(0, 0)
+
+  #   assert_equal expected, actual
+
+  #   # Test invalid move northeast ouside the chessboard
+  #   bishop.update(:x_position => 1, :y_position => 8)
+
+  #   actual = bishop.valid_move?(0, 9)
+
+  #   assert_equal expected, actual
+  # end
+end

--- a/test/models/bishop_test.rb
+++ b/test/models/bishop_test.rb
@@ -1,10 +1,20 @@
 require 'test_helper'
 
 class BishopTest < ActiveSupport::TestCase
-  test "moves that are valid" do
-    bishop = Piece.create(:type => 'Bishop', :x_position => 5, :y_position => 5)
+  test "moves that are valid diagonals" do
+    game = Game.create
 
-    # Assume is_obstructed? == false (this means there are no obstructions)
+    # Deactivate all pieces except for bishops
+    pieces_to_deactivate = game.pieces.where.not(:type => 'Bishop')
+
+    pieces_to_deactivate.update_all(:active => 0)
+
+    # Find any bishop
+    bishop = game.pieces.find_by(:type => 'Bishop')
+
+    # Update its position so it doesn't run into anything
+    bishop.update(:x_position => 5, :y_position => 5)
+
     expected = true
     
     # Test 1 sqare move northeast
@@ -12,131 +22,114 @@ class BishopTest < ActiveSupport::TestCase
 
     assert_equal expected, actual
 
-    # Test a valid move southeast
+    # Test move far northeast
+    actual = bishop.valid_move?(8, 8)
+
+    assert_equal expected, actual
+
+    # Test 1 sqare move southeast
     actual = bishop.valid_move?(6, 4)
 
     assert_equal expected, actual
 
-    # Test a valid move southwest
+    # Test move far southeast
+    actual = bishop.valid_move?(8, 2)
+
+    assert_equal expected, actual
+
+    # Test 1 sqare move southwest
     actual = bishop.valid_move?(4, 4)
 
     assert_equal expected, actual
 
-    # Test a valid move northwest
+    # Test move far southwest
+    actual = bishop.valid_move?(1, 1)
+
+    assert_equal expected, actual
+
+    # Test 1 sqare move northwest
     actual = bishop.valid_move?(4, 6)
+
+    assert_equal expected, actual
+
+    # Test move far northwest
+    actual = bishop.valid_move?(2, 8)
 
     assert_equal expected, actual
   end
 
-  # test "moves that are invalid" do
-  #   bishop = Piece.create(:type => 'Bishop', :x_position => 5, :y_position => 5)
+  test "moves that are not diagonals" do
+    game = Game.create
 
-  #   # Assume is_obstructed? == false (this means there are no obstructions)
+    # Deactivate all pieces except for bishops
+    pieces_to_deactivate = game.pieces.where.not(:type => 'Bishop')
+
+    pieces_to_deactivate.update_all(:active => 0)
+
+    # Find any bishop
+    bishop = game.pieces.find_by(:type => 'Bishop')
     
-  #   expected = false
+    expected = false
 
-  #   # Test invalid move east
-  #   actual = bishop.valid_move?(7, 5)
+    # Test invalid move east
+    actual = bishop.valid_move?(6, 5)
 
-  #   assert_equal expected, actual
+    assert_equal expected, actual
 
-  #   # Test invalid move west
-  #   actual = bishop.valid_move?(3, 5)
+    # Test invalid move west
+    actual = bishop.valid_move?(4, 5)
 
-  #   assert_equal expected, actual
+    assert_equal expected, actual
 
-  #   # Test invalid move south
-  #   actual = bishop.valid_move?(5, 3)
+    # Test invalid move south
+    actual = bishop.valid_move?(5, 4)
  
-  #   assert_equal expected, actual
+    assert_equal expected, actual
 
-  #   # Test invalid move north
-  #   actual = bishop.valid_move?(5, 7)
+    # Test invalid move north
+    actual = bishop.valid_move?(5, 6)
 
-  #   assert_equal expected, actual
+    assert_equal expected, actual
 
-  #   # Test invalid move northeast
-  #   actual = bishop.valid_move?(7, 7)
+    #--------------------------------------------------
+    # Tests for edge cases:
 
-  #   assert_equal expected, actual
+    # Test invalid non-move where the params match the piece's current location
+    actual = bishop.valid_move?(5, 5)
 
-  #   # Test invalid move southeast
-  #   actual = bishop.valid_move?(7, 3)
+    assert_equal expected, actual
 
-  #   assert_equal expected, actual
+    # Test invalid move northeast ouside the chessboard
+    actual = bishop.valid_move?(9, 9)
 
-  #   # Test invalid move southwest
-  #   actual = bishop.valid_move?(3, 3)
+    assert_equal expected, actual
 
-  #   assert_equal expected, actual
+    # Test invalid move southeast ouside the chessboard
+    actual = bishop.valid_move?(9, 1)
 
-  #   # Test invalid move northwest
-  #   actual = bishop.valid_move?(3, 7)
+    assert_equal expected, actual
 
-  #   assert_equal expected, actual
+    # Test invalid move soutwest ouside the chessboard
+    actual = bishop.valid_move?(0, 0)
 
-  #   #--------------------------------------------------
-  #   # Tests for edge cases:
+    assert_equal expected, actual
 
-  #   # Test invalid non-move where the params match the piece's current location
-  #   actual = bishop.valid_move?(5, 5)
+    # Test invalid move northwest ouside the chessboard
+    actual = bishop.valid_move?(1, 9)
 
-  #   assert_equal expected, actual
+    assert_equal expected, actual
+  end
 
-  #   # Test invalid move east ouside the chessboard
-  #   bishop.update(:x_position => 8, :y_position => 5)
+  test "ensure obstructions are detected" do
+    game = Game.create
 
-  #   actual = bishop.valid_move?(9, 5)
+    bk_sq_white_bishop = game.pieces.find_by(:x_position => 3, :y_position => 1)
 
-  #   assert_equal expected, actual
+    expected = false
 
-  #   # Test invalid move south ouside the chessboard
-  #   bishop.update(:x_position => 5, :y_position => 1)
+    # Give this bishop a destination on a diagonal path obstructed by a pawn
+    actual = bk_sq_white_bishop.valid_move?(5, 3)
 
-  #   actual = bishop.valid_move?(5, 0)
-
-  #   assert_equal expected, actual
-
-  #   # Test invalid move west ouside the chessboard
-  #   bishop.update(:x_position => 1, :y_position => 5)
-
-  #   actual = bishop.valid_move?(0, 5)
-
-  #   assert_equal expected, actual
-
-  #   # Test invalid move north ouside the chessboard
-  #   bishop.update(:x_position => 5, :y_position => 8)
-
-  #   actual = bishop.valid_move?(5, 9)
-
-  #   assert_equal expected, actual
-
-  #   # Test invalid move northeast ouside the chessboard
-  #   bishop.update(:x_position => 8, :y_position => 8)
-
-  #   actual = bishop.valid_move?(9, 9)
-
-  #   assert_equal expected, actual
-
-  #   # Test invalid move southeast ouside the chessboard
-  #   bishop.update(:x_position => 8, :y_position => 1)
-
-  #   actual = bishop.valid_move?(9, 0)
-
-  #   assert_equal expected, actual
-
-  #   # Test invalid move southwest ouside the chessboard
-  #   bishop.update(:x_position => 1, :y_position => 1)
-
-  #   actual = bishop.valid_move?(0, 0)
-
-  #   assert_equal expected, actual
-
-  #   # Test invalid move northeast ouside the chessboard
-  #   bishop.update(:x_position => 1, :y_position => 8)
-
-  #   actual = bishop.valid_move?(0, 9)
-
-  #   assert_equal expected, actual
-  # end
+    assert_equal expected, actual
+  end
 end

--- a/test/models/game_test.rb
+++ b/test/models/game_test.rb
@@ -1,6 +1,5 @@
 require 'test_helper'
 
-
 class GameTest < ActiveSupport::TestCase
   test "number of pawns" do
     game = Game.create


### PR DESCRIPTION
This branch ensures that only valid diagonal moves can be sent to a bishop. I feel it's ready to be merged; so please give it a thumbs-up if the code feels good to you.

Note: The `valid_move` function here also calls the `is_obstructed?` function to ensure there are no obstructions in between a piece and its destination. This branch also includes unit tests, and all of them are passing.